### PR TITLE
Copy versions from all subclasses, not just direct ones

### DIFF
--- a/Codex.sc
+++ b/Codex.sc
@@ -18,7 +18,7 @@ Codex {
 			);
 		};
 		cache = Dictionary.new;
-		this.subclasses.do(_.copyVersions);
+		this.allSubclasses.do(_.copyVersions);
 	}
 
 	*new { | moduleSet, from |


### PR DESCRIPTION
Make sure that every subclass of Codex copies its potential versions; not just the direct ones.